### PR TITLE
removed mid-sentence / paragraph line breaks

### DIFF
--- a/src/content/getting-started/snippets.md
+++ b/src/content/getting-started/snippets.md
@@ -2,8 +2,7 @@
 
 ### So What Are Snippets?
 
-Snippets are reusable 'chunks' of html, css and js that are specific to your documentation. They can be viewed as a type of 'poor mans' component.
-By design they are simple to use and create. The best way to understand snippets is to write one, so lets get started.
+Snippets are reusable 'chunks' of html, css and js that are specific to your documentation. They can be viewed as a type of 'poor mans' component. By design they are simple to use and create. The best way to understand snippets is to write one, so lets get started.
 
 ### Anatomy of a Snippet
 By convention a snippet __must__ have the following structure:
@@ -28,8 +27,7 @@ Snippets can be nested multiple levels deep. This can be useful if you need to g
 [/wrap]
 
 ### Using Snippets
-Snippets are simple to use. Inside of any __Markdown__ file you can render a snippet using the following custom __shortcode__ syntax. Using the __square bracket__
-notation with the keyword __render__ tells Swanky to look for a snippet with the following name and provide it with any additional attributes e.g. `[render [snippet-name] [attributes]]`.
+Snippets are simple to use. Inside of any __Markdown__ file you can render a snippet using the following custom __shortcode__ syntax. Using the __square bracket__ notation with the keyword __render__ tells Swanky to look for a snippet with the following name and provide it with any additional attributes e.g. `[render [snippet-name] [attributes]]`.
 
 
 #### Example:
@@ -42,9 +40,7 @@ notation with the keyword __render__ tells Swanky to look for a snippet with the
 [render colour-drop hex="#2E2E2E" rgb="46 46 46" name="Night Rider"]
 [/wrap]
 
-In addition to simply rendering a snippet you can also display the __markup__ that was used to generate the snippet. 
-This can be very useful if you need to show the implementation of an element within your documentation. e.g. example button HTML. 
-Using the keyword `code` in the following __shortcode__ structure will tell Swanky to render the snippet and to display the HTML in a code block below.
+In addition to simply rendering a snippet you can also display the __markup__ that was used to generate the snippet. This can be very useful if you need to show the implementation of an element within your documentation. e.g. example button HTML. Using the keyword `code` in the following __shortcode__ structure will tell Swanky to render the snippet and to display the HTML in a code block below.
 
 #### Example:
 ```markdown


### PR DESCRIPTION
line breaks in this .md are causing `<br class>` tags to get inserted in the paragraphs